### PR TITLE
Fix incompatibility with Sponge

### DIFF
--- a/src/main/java/landmaster/landcraft/world/gen/CinnamonWorldgen.java
+++ b/src/main/java/landmaster/landcraft/world/gen/CinnamonWorldgen.java
@@ -26,7 +26,7 @@ public class CinnamonWorldgen implements IWorldGenerator {
 	@Override
 	public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator,
 			IChunkProvider chunkProvider) {
-		if (chunkGenerator instanceof LandiaChunkGenerator) {
+		if (world.provider instanceof LandiaWorldProvider) {
 			BlockPos pos = new BlockPos(chunkX*16+8, 0, chunkZ*16+8);
 			if (allowedBiomes.contains(world.getBiome(pos))) {
 				int xSpawn = pos.getX() + random.nextInt(16);

--- a/src/main/java/landmaster/landcraft/world/gen/LandiaOreWorldgen.java
+++ b/src/main/java/landmaster/landcraft/world/gen/LandiaOreWorldgen.java
@@ -19,7 +19,7 @@ public class LandiaOreWorldgen implements IWorldGenerator {
 	@Override
 	public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator,
 			IChunkProvider chunkProvider) {
-		if (chunkGenerator instanceof LandiaChunkGenerator) {
+		if (world.provider instanceof LandiaWorldProvider) {
 			generateOres(world, random, new BlockPos(chunkX*16, 0, chunkZ*16));
 		}
 	}

--- a/src/main/java/landmaster/landcraft/world/gen/LandiaPlantWorldgen.java
+++ b/src/main/java/landmaster/landcraft/world/gen/LandiaPlantWorldgen.java
@@ -22,7 +22,7 @@ public abstract class LandiaPlantWorldgen implements IWorldGenerator {
 	@Override
 	public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator,
 			IChunkProvider chunkProvider) {
-		if (chunkGenerator instanceof LandiaChunkGenerator) {
+		if (world.provider instanceof LandiaWorldProvider) {
 			this.genPlantNormally(world, random, new BlockPos(chunkX*16, 0, chunkZ*16), getState(), getAmount());
 		}
 	}

--- a/src/main/java/landmaster/landcraft/world/gen/OliveWorldgen.java
+++ b/src/main/java/landmaster/landcraft/world/gen/OliveWorldgen.java
@@ -26,7 +26,7 @@ public class OliveWorldgen implements IWorldGenerator {
 	@Override
 	public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator,
 			IChunkProvider chunkProvider) {
-		if (chunkGenerator instanceof LandiaChunkGenerator) {
+		if (world.provider instanceof LandiaWorldProvider) {
 			BlockPos pos = new BlockPos(chunkX*16+8, 0, chunkZ*16+8);
 			if (allowedBiomes.contains(world.getBiome(pos))) {
 				int xSpawn = pos.getX() + random.nextInt(16);


### PR DESCRIPTION
Due to Sponge passing it's own `ChunkGenerator` into the `generate` method for WorldGen the check `chunkGenerator instanceof LandiaChunkGenerator` will fail resulting in no LandCraft world generation occurring.

This PR changes that check to `world.provider instanceof LandiaWorldProvider` which still ensures the World is a LandCraft world but is also compatible with Sponge.

More Information regarding this issue: https://github.com/SpongePowered/SpongeForge/issues/2597#issuecomment-460887664